### PR TITLE
frama-c.24.0: restrict coq to < 8.16.1

### DIFF
--- a/packages/frama-c/frama-c.24.0/opam
+++ b/packages/frama-c/frama-c.24.0/opam
@@ -128,7 +128,7 @@ depopts: [
   # Coq: because .vo would would not be loadable by another version of Coq
   # libraries: because we use dynamic linking
   "apron"
-  "coq"
+  "coq" { < "8.16.1" }
   "mlgmpidl"
   "ppx_deriving"
   "ppx_deriving_yojson"


### PR DESCRIPTION
coq.8.16.1 has been released, but the CI fails in #22564, due to which coq.8.16.1 is not in opam. Restrict the version for now, and unblock the Coq opam release.